### PR TITLE
[CI] Main pipeline fix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
   tests:
     name: Unit and System tests with cumulated coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
         run: "nomad version"
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"


### PR DESCRIPTION
Increasing uv github action version number (v5 -> v6), as the previous one resulted in a stuck pipeline after successful test exexution.