### PR TITLE
[PYPI][IGNORE][CI] Pypi release #2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 Package apache-airflow-providers-nomad
 
-Release: 0.0.2
-
-Release Date: |PypiReleaseDate|
-
+Release: 0.0.4
 
 # Airflow Nomad Provider
 


### PR DESCRIPTION
Due to Pypi security restrictions (being unable to publish to Pypi but only from the main branch) a number of branches had to be merged until iteratively the correct publishing pipeline got constructed.