### PR TITLE
[PYPI][IGNORE][CI] Pypi publish #3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,9 +9,8 @@ on:
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
-    environment:
-      name: pypi  # Match this with your PyPI trusted publisher
-      url: https://pypi.org/project/airflow-provider-nomad
+    environment: pypi  # Match this with your PyPI trusted publisher
+      # url: https://pypi.org/project/airflow-provider-nomad
     permissions:
       id-token: write  # Required for trusted publishing
 


### PR DESCRIPTION
Due to Pypi security restrictions (being unable to publish to Pypi but only from the `main` branch) a number of branches had to be merged until iteratively the correct publishing pipeline got constructed.