### PR TITLE
[PYPI][IGNORE][CI] Pypi release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ requires = ["flit_core==3.12.0"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "apache-airflow-providers-nomad"
+# name = "apache-airflow-providers-nomad"
+name = "airflow-provider-nomad"
 version = "0.0.4"
 description = "Provider package for Nomad (executor, operators, etc.) for Apache Airflow"
 readme = "README.rst"

--- a/pyproject.toml.template
+++ b/pyproject.toml.template
@@ -20,7 +20,8 @@ requires = ["flit_core==3.12.0"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "apache-airflow-providers-nomad"
+# name = "apache-airflow-providers-nomad"
+name = "airflow-provider-nomad"
 version = "0.0.4"
 description = "Provider package for Nomad (executor, operators, etc.) for Apache Airflow"
 readme = "README.rst"


### PR DESCRIPTION
Due to Pypi security restrictions (being unable to publish to Pypi but only from the main branch) a number of branches had to be merged until iteratively the correct publishing pipeline got constructed.